### PR TITLE
Measure

### DIFF
--- a/api/engine/hermes/middleware.rb
+++ b/api/engine/hermes/middleware.rb
@@ -1,5 +1,5 @@
 require_relative './travel'
-require 'skylight'
+require_relative '../../measure'
 
 module Hermes
   class Middleware
@@ -10,10 +10,10 @@ module Hermes
     end
 
     def call(env)
-      Skylight.instrument title: 'Hermes is checking the routing' do
-        Travel.new(env).possible? or
-          return missing_collection
-      end
+      travel = measure(Travel.new(env))
+
+      travel.possible? or
+        return missing_collection
 
       @app.(env)
     end
@@ -25,6 +25,12 @@ module Hermes
         [{ errors: ['Collection could not be found'] }.to_json],
         404,
         { 'Content-Type' => 'application/json' }
+    end
+
+    def measure(travel)
+      Measure.new travel, {
+        :possible? => 'Hermes is checking the routing'
+      }
     end
   end
 end

--- a/api/measure.rb
+++ b/api/measure.rb
@@ -1,0 +1,26 @@
+require 'skylight'
+
+class Measure
+  def initialize(receiver, targets)
+    @receiver = receiver
+    @targets = targets
+  end
+
+  def respond_to_missing?(name, _)
+    @targets.keys.include? name
+  end
+
+  def method_missing(name, *args, &block)
+    if @receiver.respond_to?(name)
+      if @targets.has_key?(name)
+        Skylight.instrument(title: @targets[name]) do
+          @receiver.public_send name, *args, &block
+        end
+      else
+        @receiver.public_send name, *args, &block
+      end
+    else
+      super
+    end
+  end
+end

--- a/specs/measure_spec.rb
+++ b/specs/measure_spec.rb
@@ -1,0 +1,67 @@
+require 'rspec'
+require_relative '../api/measure'
+
+RSpec.describe Measure do
+  let(:klass) do
+    Class.new do
+      def foo
+        'foo'
+      end
+      def no_foo
+        'no foo'
+      end
+    end
+  end
+
+  before do
+    allow(Skylight).to receive(:instrument).and_call_original
+  end
+
+  context 'targeting an existing method' do
+    let(:receiver) do
+      Measure.new klass.new, { foo: 'foo measured' }
+    end
+
+    before do
+      allow(receiver).to receive(:foo).and_call_original
+    end
+
+    it 'should delegate and measure the method' do
+      receiver.foo.tap do |result|
+        expect(result).to eql('foo')
+        expect(receiver).to have_received(:foo)
+        expect(Skylight).to have_received(:instrument)
+          .with({ title: 'foo measured' })
+      end
+    end
+  end
+
+  context 'calling a method that is not a target' do
+    let(:receiver) do
+      Measure.new klass.new, { foo: 'foo measured' }
+    end
+
+    before do
+      allow(receiver).to receive(:no_foo).and_call_original
+    end
+
+    it 'should delegate but not measure' do
+      receiver.no_foo.tap do |result|
+        expect(result).to eql 'no foo'
+        expect(receiver).to have_received(:no_foo)
+        expect(Skylight).to_not have_received(:instrument)
+      end
+    end
+  end
+
+  context 'targeting a missing method' do
+    let(:receiver) do
+      Measure.new klass.new, { bar: 'bar measured' }
+    end
+
+    it 'should fail and not measure' do
+      expect { receiver.bar }.to raise_error(NoMethodError)
+      expect(Skylight).to_not have_received(:instrument)
+    end
+  end
+end


### PR DESCRIPTION
Skylight's instrumentation was tracking both desired methods (e.g. identifiable?, valid?) and unwanted methods (e.g. missing_api, unauthorized).

By isolating the tracking from the tracking definition I'm able to get a better measure of where I'm spending time at.
